### PR TITLE
Switch CI to Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,22 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: 10.x
+    - run: npm ci
+    - run: gulp scripts
+    - run: npm run eslint


### PR DESCRIPTION
Travis recently dropped support for free plans, and now has a limit to how many minutes per month it'll run for.

This PR adds a Github Actions equivalent we can use instead.